### PR TITLE
Issue #156: Use median exchange rate

### DIFF
--- a/app/src/main/java/hedera/hgc/hgcwallet/common/Singleton.kt
+++ b/app/src/main/java/hedera/hgc/hgcwallet/common/Singleton.kt
@@ -417,8 +417,11 @@ object Singleton {
     }
 
     private fun loadExchangeRate() {
-        defaultExchangeRate = getAllRates().mapNotNull { it.last }.let { if (it.isNotEmpty()) (it.sum() / it.count().toDouble()) else defaultExchangeRate }
-
+        val rates = getAllRates().mapNotNull{ it.last }.sorted()
+        if (rates.isEmpty()) { return }
+        val lowerMedianIndex = rates.count() / 2
+        val offset = if (rates.count() % 2 == 0) 1 else 0
+        defaultExchangeRate = (rates[lowerMedianIndex] + rates[lowerMedianIndex - offset]) / 2
     }
 
     fun getAllRates(): List<ExchangeRateInfo> {

--- a/app/src/main/java/hedera/hgc/hgcwallet/ui/main/navigation_menu/ExchangeRateScreen.kt
+++ b/app/src/main/java/hedera/hgc/hgcwallet/ui/main/navigation_menu/ExchangeRateScreen.kt
@@ -65,7 +65,7 @@ class ExchangeRateView(context: Context, val params: ExchangeRateScreen.Params) 
         }
 
         findViewById<TextView>(R.id.tv_avg_exchange_rate)?.apply {
-            text = "1 ${context.getString(R.string.text_hgc_currency_icon)} = ${Singleton.formatUSD(Singleton.hgcToUSD(Singleton.toNanoCoins(1.0)), true, maxFractionDigitCount = 4)}"
+            text = "1 ${context.getString(R.string.text_hgc_currency_icon)} = ${Singleton.formatUSD(Singleton.hgcToUSD(Singleton.toNanoCoins(1.0)), true, maxFractionDigitCount = 99)}"
         }
     }
 }


### PR DESCRIPTION
The app prior to this change displayed the exchange rate as the mean of
the queried exchanges' rates.  After this change, the median is used
instead.

Tested manually with even and odd numbers of exchanges.  With even
numbers, the average of the two elements closest to the middle are taken
as is traditional.