### PR TITLE
Issue #155: Get CircleCI passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  andr-environment-setup:
+    working_directory: ~/dev
+    docker:
+      - image: circleci/android:api-28
+    steps:
+      - checkout
+workflows:
+  version: 2
+  build-and-unit-test:
+    jobs:
+      - andr-environment-setup


### PR DESCRIPTION
Before this change, CircleCI was failing us because we have no
configuration at all.  This adds a configuration that just makes sure
CircleCI can check out our code.