### PR TITLE
Issue #173: Remove CA URL

### DIFF
--- a/app/src/main/java/hedera/hgc/hgcwallet/ui/scan/QRPreviewScreen.kt
+++ b/app/src/main/java/hedera/hgc/hgcwallet/ui/scan/QRPreviewScreen.kt
@@ -68,7 +68,8 @@ class QRPreviewView(context: Context, val param: QRPreviewScreen.Params) : BaseS
     }
 
     fun reloadData() {
-        qrCodeDescription?.text = param.qrString
+        qrCodeDescription?.text = "" // FIXME: trace removal to root
+                                     // was: param.qrString
         param.bitmap?.let {
             qrCodeImage?.setImageBitmap(it)
         }


### PR DESCRIPTION
Remove the create account URL from the create account request screen.

Testing: Manual confirmation

Not done: Did not remove all new dead code.  Followup filed as #174.